### PR TITLE
Corrected spelling mistakes

### DIFF
--- a/src/dev/wolveringer/NPC/NPC.java
+++ b/src/dev/wolveringer/NPC/NPC.java
@@ -98,7 +98,7 @@ public final class NPC {
 	
 	public void setPing(int ping) {
 		this.ping = ping;
-		if (tab) brotcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_PING, new PlayerInfoData(profile, ping, 0, tabname)));
+		if (tab) broadcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_PING, new PlayerInfoData(profile, ping, 0, tabname)));
 	}
 	
 	public int getPing() {
@@ -137,8 +137,8 @@ public final class NPC {
 	public void setLocation(Location location) {
 		this.location = location;
 		rebuild();
-		brotcastPacket(new PacketPlayOutEntityTeleport(ID, location));
-		brotcastPacket(new PacketPlayOutEntityHeadRotation(ID, location.getYaw()));
+		broadcastPacket(new PacketPlayOutEntityTeleport(ID, location));
+		broadcastPacket(new PacketPlayOutEntityHeadRotation(ID, location.getYaw()));
 	}
 	
 	public HumanDataWatcher getDatawatcher() {
@@ -170,8 +170,8 @@ public final class NPC {
 	}
 	
 	public void setTabListed(boolean listed) {
-		if (tab != listed) if (tab) brotcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.ADD_PLAYER, new PlayerInfoData(profile, ping, 0, (IChatBaseComponent) tabname)));
-		else brotcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.REMOVE_PLAYER, new PlayerInfoData(profile, ping, 0, tabname)));
+		if (tab != listed) if (tab) broadcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.ADD_PLAYER, new PlayerInfoData(profile, ping, 0, (IChatBaseComponent) tabname)));
+		else broadcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.REMOVE_PLAYER, new PlayerInfoData(profile, ping, 0, tabname)));
 		this.tab = listed;
 	}
 	
@@ -181,7 +181,7 @@ public final class NPC {
 	
 	public void setPlayerListName(IChatBaseComponent name) {
 		this.tabname = name;
-		brotcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME, new PlayerInfoData(profile, ping, 0, tabname)));
+		broadcastPacket(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.UPDATE_DISPLAY_NAME, new PlayerInfoData(profile, ping, 0, tabname)));
 	}
 	
 	public IChatBaseComponent getPlayerListName() {
@@ -209,8 +209,17 @@ public final class NPC {
 		viewer.add(p);
 		sendSpawn(p);
 	}
-	
+
+	/**
+	 * Contains spelling mistake
+	 * @deprecated Use {@link #broadcastPacket(Packet a)} instead.  
+	 */
+	@Deprecated
 	private void brotcastPacket(Packet p) {
+		broadcastPacket(p);
+	}
+	
+	private void broadcastPacket(Packet p) {
 		for (Player pl : viewer)
 			pl.sendPacket((PacketPlayOut) p);
 	}

--- a/src/dev/wolveringer/api/inventory/Inventory.java
+++ b/src/dev/wolveringer/api/inventory/Inventory.java
@@ -47,7 +47,7 @@ public class Inventory {
 				if(autoUpdate){
 					int slot = getSlot(is);
 					if(slot != -1)
-						brotcast(new PacketPlayOutSetSlot(is, ID, slot));
+						broadcast(new PacketPlayOutSetSlot(is, ID, slot));
 				}
 			}
 		};
@@ -100,8 +100,17 @@ public class Inventory {
 				}
 			}
 	}
-
+	
+	/**
+	 * Contains spelling mistake
+	 * @deprecated Use {@link #broadcast(Packet a)} instead.  
+	 */
+	@Deprecated
 	private void brotcast(Packet a) {
+		broadcast(a);
+	}
+	
+	private void broadcast(Packet a) {
 		for(Player p : viewer)
 			p.sendPacket((PacketPlayOut) a);
 	}
@@ -156,7 +165,7 @@ public class Inventory {
 		if(is != null)
 			((CraftItemMeta) is.getItemMeta()).addMetaListener(this.imcil);
 		if(autoUpdate)
-			brotcast(new PacketPlayOutSetSlot(is, ID, slot));
+			broadcast(new PacketPlayOutSetSlot(is, ID, slot));
 	}
 
 	public void setItem(int i, Item item) {
@@ -210,9 +219,9 @@ public class Inventory {
 				e.UTF_8 = true;
 				p.sendPacket(e);
 			}
-			brotcast(new PacketPlayOutWindowItems(ID, this.container.getContains()));
+			broadcast(new PacketPlayOutWindowItems(ID, this.container.getContains()));
 		}else{
-			brotcast(new PacketPlayOutWindowItems(ID, this.container.getContains()));
+			broadcast(new PacketPlayOutWindowItems(ID, this.container.getContains()));
 		}
 	}
 

--- a/src/dev/wolveringer/api/inventory/PlayerInventory.java
+++ b/src/dev/wolveringer/api/inventory/PlayerInventory.java
@@ -43,7 +43,16 @@ public final class PlayerInventory {
 		this(player,0,"");
 	}
 
+	/**
+	 * Contains spelling mistake
+	 * @deprecated Use {@link #broadcast(Packet a)} instead.  
+	 */
+	@Deprecated
 	private void brotcast(Packet a) {
+		broadcast(a);
+	}
+
+	private void broadcast(Packet a) {
 		player.sendPacket((PacketPlayOut)a);
 	}
 
@@ -71,11 +80,11 @@ public final class PlayerInventory {
 		items.set(slot, is);
 		if(player.isInventoryOpened()){
 			if(slot > 8){
-				brotcast(new PacketPlayOutSetSlot(is, Inventory.ID, slot-9+player.getInventoryView().getSlots()));
+				broadcast(new PacketPlayOutSetSlot(is, Inventory.ID, slot-9+player.getInventoryView().getSlots()));
 			}
 		}
 		else
-			brotcast(new PacketPlayOutSetSlot(is, ID, slot));
+			broadcast(new PacketPlayOutSetSlot(is, ID, slot));
 	}
 
 	public ArrayList<Player> getViewer() {


### PR DESCRIPTION
Renamed `brotcast` to `broadcast` and marked `brotcast` as deprecated.
Same with `brotcastPacket`.

May remove `brotcast` methods in next version.
