### PR TITLE
Fix player inventory fill offset on bukkit chest open

### DIFF
--- a/src/dev/wolveringer/bungeeutil/packetlib/handler/MainPacketHandler.java
+++ b/src/dev/wolveringer/bungeeutil/packetlib/handler/MainPacketHandler.java
@@ -323,7 +323,7 @@ public class MainPacketHandler {
 				}
 			}
 			else { //Sots of inv - Player inventory
-				int base = pl.getItems().length-e.getPlayer().getPlayerInventory().getSlots()+9; //Armor and crafting dont will be sended
+				int base = pl.getItems().length-e.getPlayer().getPlayerInventory().getSlots()+10; //Armor and crafting dont will be sended
 				for(int i = base;i<pl.getItems().length;i++){
 					Item _new = pl.getItems()[i];
 					Item other = null;


### PR DESCRIPTION
When opening a Minecraft chest or a custom menu from bukkit, PlayerInventory update with a +1 offset.